### PR TITLE
fix: resolve SLF4J conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
             <version>2.0.30</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
@@ -39,6 +43,10 @@
             <artifactId>epublib-core</artifactId>
             <version>3.1</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
## Summary
- exclude legacy slf4j-api from pdfbox and epublib to allow Spring Boot's logback configuration

## Testing
- `mvn test -e` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afd4bed4f08327ab419b6afc8d3cdc